### PR TITLE
fix: release servos at destruct

### DIFF
--- a/src/ContinuousServo.cpp
+++ b/src/ContinuousServo.cpp
@@ -34,6 +34,8 @@ ContinuousServo::ContinuousServo(const PCA9685* pca9685, const uint8_t channel)
 ContinuousServo::~ContinuousServo()
 {
 	setThrottle(0.0f);
+  // send zero pwm to release servo
+  mPCA9685->setDutyCycle(mChannel, 0);
 }
 
 void ContinuousServo::initialise(const int minPulse, const int maxPulse)


### PR DESCRIPTION
I noticed that after program finishes servo for steering is still locked. I think it is not critical, but code I provided solves this issue providing 0 PWM on servo at exit.